### PR TITLE
Use graceful-fs, Fix EMFILE Errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-var fs = require('fs');
+var fs = require('graceful-fs');
 var path = require('path');
 var findModules = require('find-modules');
 var async = require('async');

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "dependencies": {
     "async": "^1.5.1",
     "find-modules": "~0.2.0",
+	"graceful-fs": "^4.1.9",
     "mkdirp": "^0.5.1"
   },
   "devDependencies": {
@@ -65,7 +66,6 @@
     "eslint-config-strict": "^7.0.4",
     "eslint-plugin-filenames": "^0.2.0",
     "ghooks": "^1.0.1",
-    "graceful-fs": "^4.1.9",
     "rimraf": "^2.5.0",
     "semantic-release": "^4.3.5",
     "tap": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint-config-strict": "^7.0.4",
     "eslint-plugin-filenames": "^0.2.0",
     "ghooks": "^1.0.1",
+    "graceful-fs": "^4.1.9",
     "rimraf": "^2.5.0",
     "semantic-release": "^4.3.5",
     "tap": "^5.0.0",


### PR DESCRIPTION
npm-assets was failing for the Windows users on our team with the following error:

`Error: EMFILE, too many open files`

To fix this, we swapped fs out for [graceful-fs](https://www.npmjs.com/package/graceful-fs).